### PR TITLE
Fix double ds_unlock call per reported issue.

### DIFF
--- a/server/dial_server.c
+++ b/server/dial_server.c
@@ -638,7 +638,6 @@ int DIAL_register_app(DIALServer *ds, const char *app_name,
     ds_lock(ds);
     ptr = find_app(ds, app_name);
     if (*ptr != NULL) {  // app already registered
-        ds_unlock(ds);
         ret = 0;
     } else {
         app = malloc(sizeof(DIALApp));


### PR DESCRIPTION
Got rid of double ds_unlock call.  See: [Issue #5](https://github.com/Netflix/dial-reference/issues/5).