### PR TITLE
Fix build errors on Ubuntu Xenial 64 bit.

### DIFF
--- a/client/build.sh
+++ b/client/build.sh
@@ -1,5 +1,4 @@
-TARGET=/usr/local/i686-netflix-linux-gnu-4.3/bin/i686-netflix-linux-gnu- \
-LDFLAGS="-L/usr/local/i686-netflix-linux-gnu-4.3/netflix/lib \
--Wl,-rpath,/usr/local/i686-netflix-linux-gnu-4.3/netflix/lib" \
-INCLUDES=-I/usr/local/i686-netflix-linux-gnu-4.3/netflix/include \
+export TARGET=/usr/local/i686-netflix-linux-gnu-4.3/bin/i686-netflix-linux-gnu-
+export LDFLAGS="-L/usr/local/i686-netflix-linux-gnu-4.3/netflix/lib -Wl,-rpath,/usr/local/i686-netflix-linux-gnu-4.3/netflix/lib -Wl,--allow-shlib-undefined"
+export INCLUDES=-I/usr/local/i686-netflix-linux-gnu-4.3/netflix/include
 make

--- a/server/makefile
+++ b/server/makefile
@@ -10,7 +10,7 @@ HEADERS := $(wildcard *.h)
 
 %.o: %.c $(HEADERS)
 #	$(CC) -Wall -Werror -g -std=gnu99 $(CFLAGS) -c $*.c -o $*.o
-	$(CC) -Wall -g -std=gnu99 $(CFLAGS) -c $*.c -o $*.o
+	$(CC) -Wall -g -fPIC -std=gnu99 $(CFLAGS) -c $*.c -o $*.o
 
 all: dialserver test
 


### PR DESCRIPTION
Add -fPIC flag for building the lib, also add -Wl,--allow-shlib-undefined
in the client LDFLAGS.