### PR TITLE
Fix regular expression for appUrl.replace.

### DIFF
--- a/server/tests/js_tests/libs/dialClient.js
+++ b/server/tests/js_tests/libs/dialClient.js
@@ -279,7 +279,7 @@ function constructAppResourceUrl(host, appName) {
     return new Q()
       .then(getAppsUrl.bind(null, host))
       .then(function (appUrl) {
-          return appUrl.replace(/\/+$/, `/${appName}`);
+          return appUrl.replace(/\/*$/, `/${appName}`);
       });
 }
 


### PR DESCRIPTION
Dear team,
In Dial 2.2 version, The Line#282 have to be changed like this -> 
appUrl.replace(/\/+$/, `/${appName}`);  => appUrl.replace(/\/*$/, `/${appName}`);

The regular Expression might be changed + to *. This is because, the + case isn't covered what if there is no '/' after of http://IP Address/Port/apps
Also, According to DIAL 2.2 Document, There isn't mention that '/' should be after the http://IPAddress/Port/apps

So, using * symbol would be better to cover both of No '/' case and '/' case. 
Thanks,