### PR TITLE
fix missing unlock

### DIFF
--- a/server/dial_server.c
+++ b/server/dial_server.c
@@ -949,6 +949,7 @@ int DIAL_register_app(DIALServer *ds, const char *app_name,
         if (corsAllowedOrigin && strlen(corsAllowedOrigin) < sizeof(app->corsAllowedOrigin)) {
             strcpy(app->corsAllowedOrigin, corsAllowedOrigin);
         } else {
+            ds_unlock(ds);
             return -1;
         }
         *ptr = app;


### PR DESCRIPTION
Fix a missing ds_unlock() call that causes later ds_lock() calls wait for the mutex forever.