### PR TITLE
fix merge error in https://github.com/Netflix/dial-reference/pull/25

### DIFF
--- a/server/dial_server.c
+++ b/server/dial_server.c
@@ -482,7 +482,6 @@ static void handle_dial_data(struct mg_connection *conn,
 
     app->dial_data = parse_params(body);
     store_dial_data(app->name, app->dial_data);
-    free_dial_data(&app->dial_data);
 
     mg_printf(conn, "HTTP/1.1 200 OK\r\n"
               "Access-Control-Allow-Origin: %s\r\n"


### PR DESCRIPTION
don't clear app->dial_data again after setting it

Seems like a merge error introduced in https://github.com/Netflix/dial-reference/pull/25

Originally discovered internally by Joonhee Shin @ Netflix (joonhees@netflix.com, joonhee.shins@gmail.com) in April this year, and also mentioned by @vshivaji8534 in https://github.com/Netflix/dial-reference/commit/93756a84eaf31579050da7d9d7f902ee367d6535?branch=93756a84eaf31579050da7d9d7f902ee367d6535&diff=split#r42028204