### PR TITLE
fixing security issue and null pointer dereference

### DIFF
--- a/client/main.cpp
+++ b/client/main.cpp
@@ -79,7 +79,7 @@ static DialServer* getServerFromUser( vector<DialServer*> list )
     printf("0: Rescan and list DIAL servers\n");
     printServerList(list);
     printf("Enter server: ");
-    scanf("%s", buf);
+    fgets(buf, 80, stdin);
     unsigned int server = atoi(buf);
     if( server > 0 && server <= list.size()){
         pServer = list[server-1];
@@ -233,7 +233,7 @@ int handleUser(DialDiscovery *pDial) {
             printf("10. Wake up on lan/wlan\n");
             printf("11. QUIT\n");
             printf("Command (0:1:2:3:4:5:6:7:8:9:10:11): ");
-            scanf("%s", buf);
+            fgets(buf, 80, stdin);
             switch( atoi(buf) )
                 {
                 case 0:
@@ -330,7 +330,10 @@ int parseArgs( int argc, char* argv[] )
             }
             break;
         case 'o':
+            if(argv[++i])
+            {
             gOutputFile = argv[++i];
+            }
             break;
         case 'a':
             gIpAddress = argv[++i];


### PR DESCRIPTION
In client there was. a buffer overflow and null pointer dereference(if -o was used without arguments).
```
➜  client git:(master) ✗ ./dialclient -o
[1]    3818535 segmentation fault  ./dialclient -o
➜  client git:(master) ✗ ./dialclient   
Sending mcast for discovery.  Please wait for 5 seconds for the response.
Found Multiple servers
0: Rescan and list DIAL servers
1: Server IP[143.110.160.145] UUID[uuid:deadbeef-dead-beef-dead-beefdeadbeef] FriendlyName[DIAL server sample] MacAddress[86:49:98:1c:2c:d3] WakeOnLanTimeout[10]
Enter server: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
*** stack smashing detected ***: terminated
[1]    3819851 abort      ./dialclient
```
Small changes to client/main.cpp should fix the issues.