### PR TITLE
Fix compile error error about array initialization

### DIFF
--- a/client/DialDiscovery.cpp
+++ b/client/DialDiscovery.cpp
@@ -314,7 +314,7 @@ void *DialDiscovery::send_mcast()
     int one = 1, my_sock;
     socklen_t addrlen;
     //struct ip_mreq mreq;
-    char send_buf[strlen((char*)ssdp_msearch) + INET_ADDRSTRLEN + 256] = {0,};
+    char send_buf[sizeof(ssdp_msearch) - 1 + INET_ADDRSTRLEN + 256] = {0,};
     int send_size;
     search_conn connection;
 


### PR DESCRIPTION
```
DialDiscovery.cpp:317:19: error: variable-sized object may not be initialized
    char send_buf[strlen((char*)ssdp_msearch) + INET_ADDRSTRLEN + 256] = {0,};
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
Fix by means of replacing run-time length calculation with a compile-time calculation.