### PR TITLE
Server: add missing include to nf_callback.c

### DIFF
--- a/server/nf_callbacks.c
+++ b/server/nf_callbacks.c
@@ -25,6 +25,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <signal.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>


### PR DESCRIPTION
```
nf_callbacks.c:130:13: error: implicit declaration of function 'kill' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
            kill((pid_t)pid, SIGTERM);
```