### PR TITLE
Port server to Darwin: enable detection of MAC address over ioctl()

### DIFF
--- a/server/quick_ssdp.c
+++ b/server/quick_ssdp.c
@@ -107,6 +107,12 @@ static void *request_handler(enum mg_event event,
     return NULL;
 }
 
+#if !defined(SIOCGIFHWADDR) && defined(__APPLE__)
+// see https://github.com/apple/darwin-xnu/blob/main/bsd/sys/sockio.h
+#define SIOCGIFHWADDR _IOWR('i', 158, struct ifreq) /* get link level addr */
+#define ifr_hwaddr ifr_addr
+#endif
+
 /**
  * Returns the local hardware address (e.g. MAC address). On macOS the "en0"
  * interface is used. On other platforms the first non-loopback interface is


### PR DESCRIPTION
This PR makes server to be compilable on Darwin (as well as on BSD-like systems). The PR https://github.com/Netflix/dial-reference/pull/50 is required in order DIAL server to be able to start correctly. Server serves multicast & HTTP requests correctly. Unfortunately detection of "applications" doesn't works since it's based on the `/proc/` file system.

Nevertheless I believe it's worth enabling the server on Darwin, since it allows at least some rudimentary testing.

P.S. faking `SIOCGIFHWADDR` is a hack but seems to be stable due to OS's backwards compatibility. Implementation of the IP/MAC detection via `getifaddrs()` would be more preferable. However even it doesn't guarantee portability and requires distinguishing  between AF_PACKET/AF_LINK (and sockaddr_ll/sockaddr_dl respectively).